### PR TITLE
Disable proxy buffering on nginx

### DIFF
--- a/Server.php
+++ b/Server.php
@@ -119,6 +119,7 @@ class Server {
         $this->_response->sendHeader('Content-Type',      self::MIME_TYPE);
         $this->_response->sendHeader('Transfer-Encoding', 'identity');
         $this->_response->sendHeader('Cache-Control',     'no-cache');
+        $this->_response->sendHeader('X-Accel-Buffering', 'no');
         $this->_response->newBuffer();
 
         return;


### PR DESCRIPTION
nginx has, by default, an output buffering. We can turn it off by using the `proxy_buffering` directive but it can be cumbersome in some cases. We let the user decide whether adding this directive or not. However, we use the `X-Accel-Buffering` header to disable the buffering for this specific resource. Please, see http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering.