### PR TITLE
Fix namespace case to `Hoa\Eventsource`.

### DIFF
--- a/Exception.php
+++ b/Exception.php
@@ -34,12 +34,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Hoa\EventSource;
+namespace Hoa\Eventsource;
 
 use Hoa\Core;
 
 /**
- * Class \Hoa\EventSource\Exception.
+ * Class \Hoa\Eventsource\Exception.
  *
  * Extending the \Hoa\Core\Exception class.
  *


### PR DESCRIPTION
Fix #14.

The namespace was `Hoa\EventSource`. This is incorrect because the library name is `Eventsource`. The namespace is fixed to `Hoa\Eventsource`, only the first letter is uppercased.